### PR TITLE
Passing ResolveInfo to globalIdField idFetcher

### DIFF
--- a/src/node/node.js
+++ b/src/node/node.js
@@ -109,12 +109,12 @@ export function fromGlobalId(globalId: string): ResolvedGlobalId {
  */
 export function globalIdField(
   typeName: string,
-  idFetcher?: (object: any) => string
+  idFetcher?: (object: any, info: GraphQLResolveInfo) => string
 ): GraphQLFieldConfig {
   return {
     name: 'id',
     description: 'The ID of an object',
     type: new GraphQLNonNull(GraphQLID),
-    resolve: (obj) => toGlobalId(typeName, idFetcher ? idFetcher(obj) : obj.id)
+    resolve: (obj,args,info) => toGlobalId(typeName, idFetcher ? idFetcher(obj,info) : obj.id)
   };
 }


### PR DESCRIPTION
Passing ResolveInfo to globalIdField idFetcher give the opportunity to build an id using the `rootValue`.
I think this can be very useful when you are working with multi-language application and need a simple and localized way to ensure Relay.Store consistent update.
